### PR TITLE
Fix: Combine workflow jobs and restrict deployment to main branch

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
   deploy-and-build:
-    # Only run on manual dispatch, on main, or when a pull request targeting `main` was merged
-    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') }}
+    # Only run on manual dispatch or when a pull request targeting `main` was merged AND we're on main
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, frickeldave-main]
     environment:
       name: github-pages


### PR DESCRIPTION
## Changes

- Combine build and deploy jobs into single `deploy-and-build` job in both workflows
- Add stricter branch protection for `deploy-prd.yml` (only main branch or manual dispatch)  
- Fix package-manager detection in `deploy-prd.yml` (comment out to use auto-detection)
- Ensure github-pages environment protection rules are respected

## Problem Solved

Fixes the issue where deployment to github-pages was rejected due to environment protection rules when merging from dev to main.

## Testing

This PR will test the complete workflow:
1. PR merge to dev (should trigger deploy-dev workflow)
2. PR merge from dev to main (should trigger deploy-prd workflow with proper branch restrictions)