### PR TITLE
Deploy: Workflow fixes for production deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,12 +9,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    # Only run when manually dispatched or when the pull request was merged (not when )
+  deploy-and-build:
+    # Only run when manually dispatched or when the pull request was merged
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
     runs-on: [self-hosted, frickeldave-main]
     steps:
-      - name: Trigger HomeNet Ansible Deployment
+      - name: Trigger HomeNet Ansible Deployment (build tag)
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.HOMENET_PAT }}
@@ -38,19 +38,14 @@ jobs:
               throw error;
             }
 
-      - name: Log deployment trigger
+      - name: Log build deployment trigger
         run: |
-          echo "Triggered HomeNet deployment via host-waltraud.yaml workflow"
+          echo "Triggered HomeNet deployment via host-waltraud.yaml workflow (build)"
           echo "Target: waltraud-dc.yaml playbook"
           echo "Limit: waltraud"
           echo "Variables: homeassistant_reset=false, tag_select=frickeldave-build"
 
-  deploy:
-    # Only run when manually dispatched or when the pull request was merged
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
-    runs-on: [self-hosted, frickeldave-main]
-    steps:
-      - name: Trigger HomeNet Ansible Deployment
+      - name: Trigger HomeNet Ansible Deployment (deploy tag)
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.HOMENET_PAT }}
@@ -74,9 +69,9 @@ jobs:
               throw error;
             }
 
-      - name: Log deployment trigger
+      - name: Log deploy deployment trigger
         run: |
-          echo "Triggered HomeNet deployment via host-waltraud.yaml workflow"
+          echo "Triggered HomeNet deployment via host-waltraud.yaml workflow (deploy)"
           echo "Target: waltraud-dc.yaml playbook"
           echo "Limit: waltraud"
           echo "Variables: homeassistant_reset=false, tag_select=frickeldave"

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -15,13 +15,19 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    # Only run on manual dispatch or when the pull request was merged
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
+  # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
+  deploy-and-build:
+    # Only run on manual dispatch, on main, or when a pull request targeting `main` was merged
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') }}
     runs-on: [self-hosted, frickeldave-main]
+    environment:
+      name: github-pages
+      # The deploy step will populate this output; kept here for clarity
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         with:
@@ -29,13 +35,6 @@ jobs:
           node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
           #package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
-  deploy:
-    needs: build
-    runs-on: [self-hosted, frickeldave-main]
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
   deploy-and-build:
-    # Only run on manual dispatch, on main, or when a pull request targeting `main` was merged
-    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') }}
+    # Only run on manual dispatch or when a pull request targeting `main` was merged AND we're on main
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, frickeldave-main]
     environment:
       name: github-pages


### PR DESCRIPTION
## Changes from dev to main

This PR merges the workflow fixes that:
- Combine build and deploy jobs into single `deploy-and-build` job
- Add stricter branch protection for `deploy-prd.yml` to respect github-pages environment rules
- Fix package-manager detection issues

## Test Case

This PR tests our fix for the environment protection issue:
- Previous error: "Branch 'dev' is not allowed to deploy to github-pages due to environment protection rules"
- Expected result: Deploy should now work because we check `github.ref == 'refs/heads/main'`

## Workflows that will trigger

1. ✅ deploy-dev workflow (already ran when merging to dev)
2. 🎯 deploy-prd workflow (will test our fix when merging to main)