### PR TITLE
Fix: Restrict production deployment to manual dispatch only

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
   deploy-and-build:
-    # Only run on manual dispatch or when a pull request targeting `main` was merged AND we're on main
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.ref == 'refs/heads/main') }}
+    # Only run on manual dispatch (workflow_dispatch) - disable automatic deployment to avoid environment protection issues
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, frickeldave-main]
     environment:
       name: github-pages


### PR DESCRIPTION
## Final Fix for Environment Protection Issue

**Problem**: Branch 'dev' is not allowed to deploy to github-pages due to environment protection rules.

**Solution**: Restrict production deployment to manual dispatch only.

## Changes

- Change `deploy-prd.yml` to only run on `workflow_dispatch`
- Removes automatic deployment on PR merge to prevent environment protection conflicts
- Production deployments now require manual trigger from GitHub Actions tab
- Dev environment deployment remains automatic

## Benefits

✅ No more environment protection rule conflicts  
✅ Explicit control over production deployments  
✅ Dev environment keeps automatic deployment  
✅ Simple and reliable solution  

## Usage

After merging to main, trigger production deployment manually:
1. Go to GitHub Actions → deploy-prd workflow
2. Click 'Run workflow' 
3. Select main branch and run