### PR TITLE
Deploy: Final fix for production deployment restrictions

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
   deploy-and-build:
-    # Only run on manual dispatch, on main, or when a pull request targeting `main` was merged
-    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') }}
+    # Only run on manual dispatch or when a pull request targeting `main` was merged AND we're on main
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.ref == 'refs/heads/main') }}
     runs-on: [self-hosted, frickeldave-main]
     environment:
       name: github-pages

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   # Combined job: performs build and then deploy. Runs only for allowed refs or manual dispatch.
   deploy-and-build:
-    # Only run on manual dispatch or when a pull request targeting `main` was merged AND we're on main
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.ref == 'refs/heads/main') }}
+    # Only run on manual dispatch (workflow_dispatch) - disable automatic deployment to avoid environment protection issues
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, frickeldave-main]
     environment:
       name: github-pages


### PR DESCRIPTION
## Final Fix for Environment Protection Issue

This PR merges the final solution to prevent environment protection rule conflicts.

## Problem Solved

- ❌ Previous issue: "Branch 'dev' is not allowed to deploy to github-pages due to environment protection rules"
- ✅ **Solution**: Production deployment now requires manual trigger only

## Changes

- `deploy-prd.yml` now only runs on `workflow_dispatch` (manual trigger)
- Removes automatic deployment on PR merge to prevent conflicts
- Dev deployment remains automatic
- Simple, reliable solution with explicit production control

## Expected Result

- ✅ No environment protection errors
- ✅ Dev workflow continues to work automatically  
- 🎯 Production deployment requires manual trigger (GitHub Actions → deploy-prd → Run workflow)

## Testing

This merge will NOT trigger automatic production deployment (by design).  
To deploy to production after merge: manually trigger the deploy-prd workflow.